### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/js/new_custom.js
+++ b/js/new_custom.js
@@ -370,7 +370,13 @@ states.forEach(state => {
 });
 
 dropdown.addEventListener("change", function() {
-  const selectedValue = dropdown.value;
-  // Redirect to the respective state page
-  window.location.href = `${selectedValue}.html`;
+  const selectedValue = dropdown.value.toLowerCase(); // Normalize the input
+  
+  // Validate selectedValue against the predefined states
+  if (states.map(state => state.toLowerCase()).includes(selectedValue)) {
+      // Redirect to the respective state page
+      window.location.href = `${selectedValue}.html`;
+  } else {
+      console.error("Invalid state selected.");
+  }
 });


### PR DESCRIPTION
Potential fix for [https://github.com/khanssen/Archstone/security/code-scanning/11](https://github.com/khanssen/Archstone/security/code-scanning/11)

To fix the issue, we need to validate the `selectedValue` before using it to construct the URL. This can be done by ensuring that the value matches one of the predefined valid states in the `states` array. Additionally, we should encode the value to prevent it from being interpreted as executable JavaScript, even if an attacker manages to inject malicious input.

The safest approach is to first validate that `selectedValue` exists in the list of predefined states (after appropriate normalization, such as converting to lowercase) before constructing the URL. If the value does not match any valid state, we should either block the action or display an error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
