### PR TITLE
Potential fix for code scanning alert no. 19: DOM text reinterpreted as HTML

### DIFF
--- a/js/slider.js
+++ b/js/slider.js
@@ -1647,6 +1647,19 @@
 
             image = $imgsToLoad.first();
             imageSource = image.attr('data-lazy');
+            
+            // Validate the imageSource URL
+            var isValidURL = /^https?:\/\/[^\s$.?#].[^\s]*$/.test(imageSource);
+            if (!isValidURL) {
+                image
+                    .removeAttr('data-lazy')
+                    .removeClass('slick-loading')
+                    .addClass('slick-lazyload-error');
+                
+                _.$slider.trigger('lazyLoadError', [ _, image, imageSource ]);
+                _.progressiveLazyLoad();
+                return;
+            }
             imageToLoad = document.createElement('img');
 
             imageToLoad.onload = function() {


### PR DESCRIPTION
Potential fix for [https://github.com/khanssen/Archstone/security/code-scanning/19](https://github.com/khanssen/Archstone/security/code-scanning/19)

To fix the issue, we need to validate or sanitize the `data-lazy` attribute value (`imageSource`) before using it. Specifically:
1. Use a whitelist of allowed domains or patterns to ensure that the `data-lazy` value is a legitimate and safe URL.
2. Alternatively, escape or encode the value before assigning it to `imageToLoad.src`, though this may not address all edge cases.

The simplest and most effective fix is to validate the `imageSource` URL using a regular expression or URL parser to ensure it comes from a trusted domain or follows the expected format.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
