### PR TITLE
Potential fix for code scanning alert no. 33: DOM text reinterpreted as HTML

### DIFF
--- a/owl carousel/OwlCarousel2-2.3.4/OwlCarousel2-2.3.4/src/js/owl.carousel.js
+++ b/owl carousel/OwlCarousel2-2.3.4/OwlCarousel2-2.3.4/src/js/owl.carousel.js
@@ -1429,6 +1429,20 @@
 	 * @todo Replace by a more generic approach
 	 * @protected
 	 */
+	// Helper to sanitize potentially unsafe src values before using in DOM
+	function sanitizeImageSrc(src) {
+		if (typeof src !== "string") return "";
+		src = src.trim();
+		// Only allow http(s) or data:image/* URLs, else empty string
+		if (/^(https?:\/\/|\/|\.\/|\.\.\/)/i.test(src)) {
+			return src;
+		}
+		if (/^data:image\//i.test(src)) {
+			return src;
+		}
+		return "";
+	}
+	
 	Owl.prototype.preloadAutoWidthImages = function(images) {
 		images.each($.proxy(function(i, element) {
 			this.enter('pre-loading');
@@ -1438,7 +1452,14 @@
 				element.css('opacity', 1);
 				this.leave('pre-loading');
 				!this.is('pre-loading') && !this.is('initializing') && this.refresh();
-			}, this)).attr('src', element.attr('src') || element.attr('data-src') || element.attr('data-src-retina'));
+			}, this)).attr(
+				'src',
+				sanitizeImageSrc(
+					element.attr('src') ||
+					element.attr('data-src') ||
+					element.attr('data-src-retina')
+				)
+			);
 		}, this));
 	};
 


### PR DESCRIPTION
Potential fix for [https://github.com/khanssen/Archstone/security/code-scanning/33](https://github.com/khanssen/Archstone/security/code-scanning/33)

The best way to fix this problem is to ensure that any value retrieved from `element.attr('src')`, `element.attr('data-src')`, or `element.attr('data-src-retina')` is sanitized or validated before being assigned to a new `<img>` element's `src` attribute in the carousel. This can be done by allowing only URLs with trusted schemes (`http:`, `https:`, or data-URIs for images) and rejecting any suspicious protocols, such as `javascript:`, `vbscript:`, or other unexpected values.

Specifically, in owl.carousel.js, lines where the src attribute of an image is set should be updated to include validation: extract the attribute, pass it through a validation/sanitization function, and only assign it if it passes (otherwise, set to empty string or skip). The validation function should ensure the src begins with a trusted scheme.

This requires:
- Defining a helper function in the file, above its first use, e.g. `sanitizeImageSrc(src)`, which returns the safe src or an empty string.
- Updating line 1441 to use this function on the attribute values.

No new imports are needed if standard JS methods are sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
