### PR TITLE
Potential fix for code scanning alert no. 27: Useless regular-expression character escape

### DIFF
--- a/documentation/assets/js/run_prettify.js
+++ b/documentation/assets/js/run_prettify.js
@@ -1254,7 +1254,7 @@ var IN_GLOBAL_SCOPE = false;
           // only when not followint [|&;<>].
           '^.[^\\s\\w.$@\'"`/\\\\]*';
         if (options['regexLiterals']) {
-          punctuation += '(?!\s*\/)';
+          punctuation += '(?!\\s*\/)';
         }
     
         fallthroughStylePatterns.push(


### PR DESCRIPTION
Potential fix for [https://github.com/khanssen/Archstone/security/code-scanning/27](https://github.com/khanssen/Archstone/security/code-scanning/27)

To fix the problem, we need to ensure the constructed regular expression string includes a valid escape sequence for whitespace (`\s`) when passed to the RegExp constructor. In JavaScript string literals, this means using `\\s`.  
Specifically, change `(?!\s*\/)` to `(?!\\s*\/)` in the string literal so that the resulting RegExp sees `\s` in the pattern.  
Only the code on line 1257 in documentation/assets/js/run_prettify.js needs to be edited. No additional imports or function definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
