### PR TITLE
Potential fix for code scanning alert no. 25: Useless regular-expression character escape

### DIFF
--- a/Content/documentation/assets/js/old run_prettify.js
+++ b/Content/documentation/assets/js/old run_prettify.js
@@ -1254,7 +1254,7 @@ var IN_GLOBAL_SCOPE = false;
           // only when not followint [|&;<>].
           '^.[^\\s\\w.$@\'"`/\\\\]*';
         if (options['regexLiterals']) {
-          punctuation += '(?!\s*\/)';
+          punctuation += '(?!\\s*\\/)';
         }
     
         fallthroughStylePatterns.push(


### PR DESCRIPTION
Potential fix for [https://github.com/khanssen/Archstone/security/code-scanning/25](https://github.com/khanssen/Archstone/security/code-scanning/25)

To fix the problem, we need to double the backslash in any string literal representing a regular expression that should reference a RegExp escape sequence. Specifically, change `'(?!\s*\/)'` to `'(?!\\s*\\/)'` on line 1257 in Content/documentation/assets/js/old run_prettify.js. This will ensure that, when concatenated and passed to `new RegExp(...)`, the result will have an actual whitespace matcher and an escaped forward slash in the RegExp, as originally intended.  

No additional imports, methods, or definitions are needed. The change is isolated to the relevant line inside the provided snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
