### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,4 +1,6 @@
 name: Super Linter
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/khanssen/Archstone/security/code-scanning/36](https://github.com/khanssen/Archstone/security/code-scanning/36)

The best way to fix the issue is to explicitly set the `permissions` key at the workflow level (above `jobs`), to restrict the default token permissions to the least required—`contents: read`—which allows the workflow to check out code but not modify repository contents. This should be added immediately after the workflow `name:` and before `on:` (i.e., between lines 1 and 2 or just after line 2). No additional methods, imports, or logic changes are needed: only the addition of this top-level YAML key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
