### PR TITLE
Potential fix for code scanning alert no. 29: DOM text reinterpreted as HTML

### DIFF
--- a/owl carousel/OwlCarousel2-2.3.4/OwlCarousel2-2.3.4/dist/owl.carousel.js
+++ b/owl carousel/OwlCarousel2-2.3.4/OwlCarousel2-2.3.4/dist/owl.carousel.js
@@ -1978,7 +1978,8 @@
 
 		$elements.each($.proxy(function(index, element) {
 			var $element = $(element), image,
-                url = (window.devicePixelRatio > 1 && $element.attr('data-src-retina')) || $element.attr('data-src') || $element.attr('data-srcset');
+                rawUrl = (window.devicePixelRatio > 1 && $element.attr('data-src-retina')) || $element.attr('data-src') || $element.attr('data-srcset'),
+                url = sanitizeUrl(rawUrl);
 
 			this._core.trigger('load', { element: $element, url: url }, 'lazy');
 


### PR DESCRIPTION
Potential fix for [https://github.com/khanssen/Archstone/security/code-scanning/29](https://github.com/khanssen/Archstone/security/code-scanning/29)

The best fix is to **sanitize the derived URL before any sink usage**, using the existing `sanitizeUrl` helper and then only using the sanitized value downstream. This addresses all three variants (`data-src-retina`, `data-src`, `data-srcset`) with one change and preserves behavior for valid URLs.

In `owl carousel/OwlCarousel2-2.3.4/OwlCarousel2-2.3.4/dist/owl.carousel.js`, update the `Lazy.prototype.load` block (around line 1981) so that:
1. The raw attribute selection is stored in a temporary variable (for clarity).
2. `url` is assigned as `sanitizeUrl(rawUrl)`.
3. Existing sinks continue using `url` (now sanitized).

No new imports or dependencies are required, since `sanitizeUrl` is already defined in the shown snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
